### PR TITLE
app-consulting-bot: support written out numbers

### DIFF
--- a/samples/app-consulting-bot/ConsultingBot/ConsultingBot.csproj
+++ b/samples/app-consulting-bot/ConsultingBot/ConsultingBot.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.6.3" />
     <PackageReference Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.2.8" />
     <PackageReference Include="Microsoft.Recognizers.Text.DateTime" Version="1.2.8" />
+    <PackageReference Include="Microsoft.Recognizers.Text.Number" Version="1.2.8" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,6 +36,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="appSettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Update="appSettings.sample.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/samples/app-consulting-bot/ConsultingBot/Model/LuisConsultingProjectRecognizer.cs
+++ b/samples/app-consulting-bot/ConsultingBot/Model/LuisConsultingProjectRecognizer.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Recognizers.Text;
 using Microsoft.Recognizers.Text.DateTime;
+using Microsoft.Recognizers.Text.Number;
 using Newtonsoft.Json.Linq;
 
 namespace ConsultingBot
@@ -126,6 +127,15 @@ namespace ConsultingBot
                     if (result <= 0)
                     {
                         result = hours * hoursMultiplier;
+                    }
+                }
+                else
+                {
+                    var possibleHours = NumberRecognizer.RecognizeNumber(val.Split(' ')[0], Culture.English);
+                    if (possibleHours.Count > 0)
+                    {
+                        possibleHours.FirstOrDefault().Resolution.TryGetValue("value", out var hoursString);
+                        result = Convert.ToDouble(hoursString) * hoursMultiplier;
                     }
                 }
             }


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no                               |
| New feature?    | yes                              |
| New sample?     | no                               |
| Related issues? | none |

## What's in this Pull Request?

This PR includes a minor update to the app-consulting-bot sample so that it now understands written out numbers in user request. For example, "Bill Contoso for three hours" now resolves to 3 hours.