### PR TITLE
More precise bot function used (onEventActivity)

### DIFF
--- a/samples/bot-meeting-lifecycle-basic/README.md
+++ b/samples/bot-meeting-lifecycle-basic/README.md
@@ -28,6 +28,7 @@ For further details see the author's [blog post](https://mmsharepoint.wordpress.
 Version|Date|Author|Comments
 -------|----|----|--------
 1.0|Sep 17, 2021|[Markus Moeller](https://twitter.com/moeller2_0)|Initial release
+1.1|Oct 07, 2021|[Markus Moeller](https://twitter.com/moeller2_0)|More precise bot function used (onEventActivity)
 
 ## Disclaimer
 

--- a/samples/bot-meeting-lifecycle-basic/src/server/botMeetingLifecycleBasicBot/BotMeetingLifecycleBasicBot.ts
+++ b/samples/bot-meeting-lifecycle-basic/src/server/botMeetingLifecycleBasicBot/BotMeetingLifecycleBasicBot.ts
@@ -24,7 +24,7 @@ export class BotMeetingLifecycleBasicBot extends TeamsActivityHandler {
         super();
     }
 
-    async onTurnActivity(context) {
+    async onEventActivity(context) {
         if (context.activity.type == 'event' && context.activity.name == "application/vnd.microsoft.meetingStart") {
             var meetingObject = context.activity.value;
             await context.sendActivity(`Meeting ${meetingObject.Title} started at ${meetingObject.StartTime}`);


### PR DESCRIPTION
|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | no |
| New feature?    | yes|
| New sample?     | no   |
| Related issues? | fixes #X, partially #Y, mentioned in #Z |

Not really relevant but to stay consistent:
While developing my follow-up sample on "meeting feedback" (coming soon) I found out that the function onTurnActivity I originally used (and took from a MSFT example ;-) ) is too generic when it comes to more different activities.
So I am convinced it is best practice to use the more specific function.